### PR TITLE
fixing flask_debug to be false by default #192

### DIFF
--- a/flask-docker-app/app.py
+++ b/flask-docker-app/app.py
@@ -24,7 +24,7 @@ def hello():
 
 if __name__ == '__main__':
     app.run(
-        debug=True,
+        debug=os.getenv('FLASK_DEBUG',False),
         host='0.0.0.0',
         port=80
     )


### PR DESCRIPTION
Fixes #192 

Running Flask applications inf debug mode results in the debugger being enabled. This can allow abitrary code execution. Documentation for Flask strongly recommends that debug mode should never be enabled on production systems.

For more info check the bandit documentation. https://bandit.readthedocs.io/en/latest/plugins/b201_flask_debug_true.html